### PR TITLE
STYLE: Improve the Strain module classes' style.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -92,6 +92,8 @@ protected:
 
   virtual void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId );
 
+  virtual void PrintSelf ( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
+
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
 

--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -71,7 +71,6 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
     }
 }
 
-
 template< class TInputImage, class TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
@@ -109,6 +108,17 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
     }
 }
 
+template< class TInputImage, class TOutputImage, unsigned int TComponents >
+void
+SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
+::PrintSelf( std::ostream & os, Indent indent ) const
+{
+  Superclass::PrintSelf( os, indent );
+
+  os << indent << "ComponentsMask: "
+    << static_cast< typename NumericTraits< ComponentsMaskType >::PrintType >( m_ComponentsMask )
+    << std::endl;
+}
 } // end namespace itk
 
 #endif

--- a/include/itkStrainImageFilter.h
+++ b/include/itkStrainImageFilter.h
@@ -89,13 +89,14 @@ public:
 
   /** Alternate type of filter used to calculate the gradients. */
   typedef ImageToImageFilter< InputImageType, GradientOutputImageType > VectorGradientFilterType;
+
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
   itkTypeMacro( StrainImageFilter, ImageToImageFilter );
 
-  /** Set the filter used to calculate the gradients internally.  The default is
+  /** Set the filter used to calculate the gradients internally. The default is
    * an itk::GradientImageFilter. */
   itkSetObjectMacro( GradientFilter, GradientFilterType );
   itkGetObjectMacro( GradientFilter, GradientFilterType );
@@ -128,6 +129,12 @@ protected:
 
   typedef itk::SplitComponentsImageFilter< InputImageType, OperatorImageType >
     InputComponentsImageFilterType;
+
+  virtual void PrintSelf ( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
+
+private:
+  ITK_DISALLOW_COPY_AND_ASSIGN(StrainImageFilter);
+
   typename InputComponentsImageFilterType::Pointer m_InputComponentsFilter;
 
   typename GradientFilterType::Pointer m_GradientFilter;
@@ -135,9 +142,6 @@ protected:
   typename VectorGradientFilterType::Pointer m_VectorGradientFilter;
 
   StrainFormType m_StrainForm;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(StrainImageFilter);
 };
 
 } // end namespace itk

--- a/include/itkStrainImageFilter.hxx
+++ b/include/itkStrainImageFilter.hxx
@@ -30,6 +30,7 @@ namespace itk
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >
 StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
 ::StrainImageFilter():
+  m_InputComponentsFilter( InputComponentsImageFilterType::New() ),
   m_StrainForm( INFINITESIMAL )
 {
   // The first output is only of interest to the user.  The rest of the outputs
@@ -41,15 +42,10 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
     this->SetNthOutput( i, GradientOutputImageType::New().GetPointer() );
     }
 
-  this->m_InputComponentsFilter = InputComponentsImageFilterType::New();
-
   typedef GradientImageFilter< OperatorImageType, TOperatorValueType, TOperatorValueType >
     GradientImageFilterType;
-  this->m_GradientFilter   = GradientImageFilterType::New().GetPointer();
-
-  this->m_VectorGradientFilter = NULL;
+  this->m_GradientFilter = GradientImageFilterType::New().GetPointer();
 }
-
 
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >
 void
@@ -90,7 +86,6 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
   OutputImageType * output = this->GetOutput();
   output->FillBuffer( NumericTraits< OutputPixelType >::Zero );
 }
-
 
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >
 void
@@ -141,8 +136,7 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
       ImageRegionConstIterator< GradientOutputImageType >
         gradientIt( reinterpret_cast< GradientOutputImageType* >(
             dynamic_cast< GradientOutputImageType* >(
-              this->ProcessObject::GetOutput( i + 1 ) ) )
-          , region );
+              this->ProcessObject::GetOutput( i + 1 ) ) ), region );
       for( outputIt.GoToBegin(), gradientIt.GoToBegin();
            !gradientIt.IsAtEnd();
            ++outputIt, ++gradientIt )
@@ -191,6 +185,23 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
     }
 }
 
+template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >
+void
+StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
+::PrintSelf( std::ostream & os, Indent indent ) const
+{
+  Superclass::PrintSelf( os, indent );
+
+  itkPrintSelfObjectMacro( InputComponentsFilter );
+
+  itkPrintSelfObjectMacro( GradientFilter );
+
+  itkPrintSelfObjectMacro( VectorGradientFilter );
+
+  os << indent << "StrainForm: "
+    << static_cast< typename NumericTraits< StrainFormType >::PrintType >( m_StrainForm )
+    << std::endl;
+}
 } // end namespace itk
 
 #endif

--- a/include/itkTransformToStrainFilter.h
+++ b/include/itkTransformToStrainFilter.h
@@ -100,11 +100,12 @@ protected:
   virtual void BeforeThreadedGenerateData() ITK_OVERRIDE;
   virtual void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) ITK_OVERRIDE;
 
-  StrainFormType m_StrainForm;
+  virtual void PrintSelf ( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
 
 private:
-  TransformToStrainFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & ); // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(TransformToStrainFilter);
+
+  StrainFormType m_StrainForm;
 };
 
 } // end namespace itk

--- a/include/itkTransformToStrainFilter.hxx
+++ b/include/itkTransformToStrainFilter.hxx
@@ -42,7 +42,6 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
   output->FillBuffer( NumericTraits< OutputPixelType >::Zero );
 }
 
-
 template < typename TTransform, typename TOperatorValue,
            typename TOutputValue >
 void
@@ -59,9 +58,9 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
   typename TransformType::JacobianType identity;
   identity.SetSize( ImageDimension, ImageDimension );
   identity.Fill( 0.0 );
-  for( unsigned int ii = 0; ii < ImageDimension; ++ii )
+  for( unsigned int i = 0; i < ImageDimension; ++i )
     {
-    identity.SetElement( ii, ii,  1.0);
+    identity.SetElement( i, i, 1.0);
     }
 
   // e_ij += 1/2( du_i/dx_j + du_j/dx_i )
@@ -73,17 +72,17 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
     typename TransformType::JacobianType jacobian;
     input->ComputeJacobianWithRespectToPosition( point, jacobian );
     typename OutputImageType::PixelType outputPixel = outputIt.Get();
-    for( unsigned int ii = 0; ii < ImageDimension; ++ii )
+    for( unsigned int i = 0; i < ImageDimension; ++i )
       {
-      for( unsigned int jj = 0; jj < ii; ++jj )
+      for( unsigned int j = 0; j < i; ++j )
         {
-        outputPixel( ii, jj ) += jacobian( ii, jj ) / static_cast< TOutputValue >( 2 );
+        outputPixel( i, j ) += jacobian( i, j ) / static_cast< TOutputValue >( 2 );
         }
-      for( unsigned int jj = ii + 1; jj < ImageDimension; ++jj )
+      for( unsigned int j = i + 1; j < ImageDimension; ++j )
         {
-        outputPixel( ii, jj ) += jacobian( ii, jj ) / static_cast< TOutputValue >( 2 );
+        outputPixel( i, j ) += jacobian( i, j ) / static_cast< TOutputValue >( 2 );
         }
-      outputPixel( ii, ii ) = jacobian( ii, ii ) - static_cast< TOutputValue >( 1 );
+      outputPixel( i, i ) = jacobian( i, i ) - static_cast< TOutputValue >( 1 );
       }
     outputIt.Set( outputPixel );
     }
@@ -102,13 +101,13 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
       input->ComputeJacobianWithRespectToPosition( point, jacobian );
       jacobian -= identity;
       typename OutputImageType::PixelType outputPixel = outputIt.Get();
-      for( unsigned int ii = 0; ii < ImageDimension; ++ii )
+      for( unsigned int i = 0; i < ImageDimension; ++i )
         {
-        for( unsigned int jj = 0; jj < ImageDimension; ++jj )
+        for( unsigned int j = 0; j < ImageDimension; ++j )
           {
-          for( unsigned int kk = 0; kk <= jj; ++kk )
+          for( unsigned int k = 0; k <= j; ++k )
             {
-            outputPixel( jj, kk ) += jacobian( ii, jj ) * jacobian( ii, kk ) / static_cast< TOutputValue >( 2 );
+            outputPixel( j, k ) += jacobian( i, j ) * jacobian( i, k ) / static_cast< TOutputValue >( 2 );
             }
           }
         }
@@ -126,13 +125,13 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
       input->ComputeJacobianWithRespectToPosition( point, jacobian );
       jacobian -= identity;
       typename OutputImageType::PixelType outputPixel = outputIt.Get();
-      for( unsigned int ii = 0; ii < ImageDimension; ++ii )
+      for( unsigned int i = 0; i < ImageDimension; ++i )
         {
-        for( unsigned int jj = 0; jj < ImageDimension; ++jj )
+        for( unsigned int j = 0; j < ImageDimension; ++j )
           {
-          for( unsigned int kk = 0; kk <= jj; ++kk )
+          for( unsigned int k = 0; k <= j; ++k )
             {
-            outputPixel( jj, kk ) -= jacobian( ii, jj ) * jacobian( ii, kk ) / static_cast< TOutputValue >( 2 );
+            outputPixel( j, k ) -= jacobian( i, j ) * jacobian( i, k ) / static_cast< TOutputValue >( 2 );
             }
           }
         }
@@ -144,6 +143,18 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
     }
 }
 
+template < typename TTransform, typename TOperatorValue,
+           typename TOutputValue >
+void
+TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
+::PrintSelf( std::ostream & os, Indent indent ) const
+{
+  Superclass::PrintSelf( os, indent );
+
+  os << indent << "StrainForm: "
+    << static_cast< typename NumericTraits< StrainFormType >::PrintType >( m_StrainForm )
+    << std::endl;
+}
 } // end namespace itk
 
 #endif


### PR DESCRIPTION
Override the PrintSelf method.

Make class ivars be private instead of protected.

Use the ITK_DISALLOW_COPY_AND_ASSIGN macro for deleting functions in a
consistent way.

SmartPointer objects initialize themselves to the null pointer.

Use initialization lists to create the
itk::StrainImageFilter::m_InputComponentsFilter.