### PR TITLE
COMP: Deprecate use itkGetObjectMacro

### DIFF
--- a/include/itkStrainImageFilter.h
+++ b/include/itkStrainImageFilter.h
@@ -99,14 +99,14 @@ public:
   /** Set the filter used to calculate the gradients internally. The default is
    * an itk::GradientImageFilter. */
   itkSetObjectMacro( GradientFilter, GradientFilterType );
-  itkGetObjectMacro( GradientFilter, GradientFilterType );
+  itkGetConstObjectMacro( GradientFilter, GradientFilterType );
 
   /** Set the filter used to calculate the gradients internally.  This filter
    * should take a Vector image as input and produce a CovariantVector gradient
    * image on each output corresponding to every Vector component.  If this
    * filter is non-NULL, it is used instead of the GradientFilter. */
   itkSetObjectMacro( VectorGradientFilter, VectorGradientFilterType );
-  itkGetObjectMacro( VectorGradientFilter, VectorGradientFilterType );
+  itkGetConstObjectMacro( VectorGradientFilter, VectorGradientFilterType );
 
   /**
    * Three different types of strains can be calculated, infinitesimal (default), aka


### PR DESCRIPTION
git grep -l "itkGetObjectMacro" |   fgrep -v itk_compiler_detection.h | fgrep -v CMakeLists.txt |fgrep -v .cmake |   xargs sed -i '' -e "s/itkGetObjectMacro/itkGetConstObjectMacro/g"

For a full description of the rational for this change
see:

commit 08df6afeb32e363104bf1e7a043f4b38d524c364
Author: Hans Johnson <hans-johnson@uiowa.edu>
Date:   Sun Dec 2 14:07:01 2012 -0600
ENH: Get function accessible from const objects