### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -49,6 +49,8 @@ class SplitComponentsImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
+
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
   /** Components enumeration. */
@@ -93,8 +95,6 @@ protected:
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
-
   ComponentsMaskType m_ComponentsMask;
 };
 

--- a/include/itkStrainImageFilter.h
+++ b/include/itkStrainImageFilter.h
@@ -66,6 +66,8 @@ class StrainImageFilter : public
                                   TInputImage::ImageDimension > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(StrainImageFilter);
+
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
@@ -132,8 +134,6 @@ protected:
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(StrainImageFilter);
-
   typename InputComponentsImageFilterType::Pointer m_InputComponentsFilter;
 
   typename GradientFilterType::Pointer m_GradientFilter;

--- a/include/itkTransformToStrainFilter.h
+++ b/include/itkTransformToStrainFilter.h
@@ -56,6 +56,8 @@ class TransformToStrainFilter : public
                                   TTransform::InputSpaceDimension > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TransformToStrainFilter);
+
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TTransform::InputSpaceDimension;
 
@@ -103,8 +105,6 @@ protected:
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TransformToStrainFilter);
-
   StrainFormType m_StrainForm;
 };
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.