### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -90,7 +90,7 @@ protected:
   /** Do not allocate outputs that we will not populate. */
   void AllocateOutputs() override;
 
-  void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const OutputRegionType& outputRegion ) override;
 
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 

--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -39,6 +39,8 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
     {
     this->SetNthOutput( i, this->MakeOutput( i ) );
     }
+
+  this->DynamicMultiThreadingOn();
 }
 
 
@@ -74,7 +76,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 template< class TInputImage, class TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
-::ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputRegionType& outputRegion )
 {
   typename InputImageType::ConstPointer input = this->GetInput();
   ProcessObject::DataObjectPointerArray outputs = this->GetOutputs();

--- a/include/itkStrainImageFilter.h
+++ b/include/itkStrainImageFilter.h
@@ -127,7 +127,7 @@ protected:
 
   void BeforeThreadedGenerateData() override;
 
-  void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const OutputRegionType& outputRegion ) override;
 
   using InputComponentsImageFilterType = itk::SplitComponentsImageFilter< InputImageType, OperatorImageType >;
 

--- a/include/itkStrainImageFilter.hxx
+++ b/include/itkStrainImageFilter.hxx
@@ -44,6 +44,8 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
 
   using GradientImageFilterType = GradientImageFilter< OperatorImageType, TOperatorValueType, TOperatorValueType >;
   this->m_GradientFilter = GradientImageFilterType::New().GetPointer();
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >
@@ -95,7 +97,7 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >
 void
 StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
-::ThreadedGenerateData( const OutputRegionType& region, ThreadIdType itkNotUsed( threadId ) )
+::DynamicThreadedGenerateData( const OutputRegionType& region )
 {
   typename InputImageType::ConstPointer input = this->GetInput();
 

--- a/include/itkTransformToStrainFilter.h
+++ b/include/itkTransformToStrainFilter.h
@@ -100,7 +100,7 @@ protected:
   TransformToStrainFilter();
 
   void BeforeThreadedGenerateData() override;
-  void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const OutputRegionType& outputRegion ) override;
 
   void PrintSelf ( std::ostream& os, Indent indent ) const override;
 

--- a/include/itkTransformToStrainFilter.hxx
+++ b/include/itkTransformToStrainFilter.hxx
@@ -30,6 +30,7 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
 ::TransformToStrainFilter():
   m_StrainForm( INFINITESIMAL )
 {
+  this->DynamicMultiThreadingOn();
 }
 
 template < typename TTransform, typename TOperatorValue,
@@ -58,8 +59,7 @@ template < typename TTransform, typename TOperatorValue,
            typename TOutputValue >
 void
 TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
-::ThreadedGenerateData( const OutputRegionType& region,
-                        ThreadIdType itkNotUsed( threadId ) )
+::DynamicThreadedGenerateData( const OutputRegionType& region )
 {
   const TransformType * input = this->GetTransform();
 


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The errors stemmed when this gerrit topic got merged:
http://review.source.kitware.com/#/c/23175/

And were later related to the following gerrit-topic:
http://review.source.kitware.com/#/c/23434/

The solution adopted in this patch set was based on the proposal in:
http://review.source.kitware.com/#/c/23439/