### PR TITLE
DOC: Add missing CI report table.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,20 @@
 ITKStrain
 =========
 
-.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKStrain.svg?style=shield
-    :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKStrain
+.. |CircleCI| image:: https://circleci.com/gh/KitwareMedical/ITKStrain.svg?style=shield
+    :target: https://circleci.com/gh/KitwareMedical/ITKStrain
 
-.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/ITKStrain.svg?branch=master
-    :target: https://travis-ci.org/InsightSoftwareConsortium/ITKStrain
+.. |TravisCI| image:: https://travis-ci.org/KitwareMedical/ITKStrain.svg?branch=master
+    :target: https://travis-ci.org/KitwareMedical/ITKStrain
 
 .. |AppVeyor| image:: https://img.shields.io/appveyor/ci/thewtex/itkstrain.svg
-    :target: https://ci.appveyor.com/project/thewtex/itkstrain
+    :target: https://ci.appveyor.com/project/KitwareMedical/ITKStrain
+
+=========== =========== ===========
+   Linux      macOS       Windows
+=========== =========== ===========
+|CircleCI|  |TravisCI|  |AppVeyor|
+=========== =========== ===========
 
 This repository contains `ITK <https://itk.org>`_ filters to estimate a
 strain tensor field from a displacement field or a spatial transformation.


### PR DESCRIPTION
Add missing CI report table. Commit e3f3209 missed to include the
continuous integration tools' results and thus the health of the
repository was not being displayed.