### PR TITLE
COMP: Use NumericTraits<T>::ZeroValue() for strain default output

### DIFF
--- a/include/itkStrainImageFilter.hxx
+++ b/include/itkStrainImageFilter.hxx
@@ -91,7 +91,7 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
     }
 
   OutputImageType * output = this->GetOutput();
-  output->FillBuffer( NumericTraits< OutputPixelType >::Zero );
+  output->FillBuffer( NumericTraits< OutputPixelType >::ZeroValue() );
 }
 
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >

--- a/include/itkTransformToStrainFilter.hxx
+++ b/include/itkTransformToStrainFilter.hxx
@@ -40,7 +40,7 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
 ::BeforeThreadedGenerateData()
 {
   OutputImageType * output = this->GetOutput();
-  output->FillBuffer( NumericTraits< OutputPixelType >::Zero );
+  output->FillBuffer( NumericTraits< OutputPixelType >::ZeroValue() );
 
   const TransformType * input = this->GetTransform();
   if( input == nullptr )


### PR DESCRIPTION
Addresses:

/home/matt/src/ITKStrain/include/itkTransformToStrainFilter.hxx:43:57: warning: instantiation of variable 'itk::NumericTraits<itk::SymmetricSecondRankTensor<float, 2> >::Zero' required here, but no definition is available [-Wundefined-var-template]
  output->FillBuffer( NumericTraits< OutputPixelType >::Zero );
                                                        ^
/home/matt/src/ITKStrain/include/itkTransformToStrainFilter.h:100:3: note: in instantiation of member function 'itk::TransformToStrainFilter<itk::Transform<double, 2, 2>, float, float>::BeforeThreadedGenerateData' requested here
  TransformToStrainFilter();
  ^
/home/matt/src/ITKStrain/include/itkTransformToStrainFilter.h:77:16: note: in instantiation of member function 'itk::TransformToStrainFilter<itk::Transform<double, 2, 2>, float, float>::TransformToStrainFilter' requested here
  itkNewMacro( Self );
               ^
/home/matt/src/ITKStrain/test/itkTransformToStrainFilterTest.cxx:56:34: note: in instantiation of member function 'itk::TransformToStrainFilter<itk::Transform<double, 2, 2>, float, float>::New' requested here
    TransformToStrainFilterType::New();
                                 ^
/home/matt/src/ITK/Modules/Core/Common/include/itkNumericTraitsTensorPixel.h:186:38: note: forward declaration of template entity is here
  static const Self ITKCommon_EXPORT Zero;
                                     ^
/home/matt/src/ITKStrain/include/itkTransformToStrainFilter.hxx:43:57: note: add an explicit instantiation declaration to suppress this warning if 'itk::NumericTraits<itk::SymmetricSecondRankTensor<float, 2> >::Zero' is explicitly instantiated in another translation unit
  output->FillBuffer( NumericTraits< OutputPixelType >::Zero );