### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  * \sa DiffusionTensor3D
  * \sa NthElementImageAdaptor
  */
-template< class TInputImage, class TOutputImage, unsigned int TComponents = TInputImage::ImageDimension >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents = TInputImage::ImageDimension >
 class SplitComponentsImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {

--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -26,7 +26,7 @@
 namespace itk
 {
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::SplitComponentsImageFilter()
 {
@@ -44,7 +44,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 }
 
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::AllocateOutputs()
@@ -73,7 +73,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
     }
 }
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::DynamicThreadedGenerateData( const OutputRegionType& outputRegion )
@@ -110,7 +110,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
     }
 }
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::PrintSelf( std::ostream & os, Indent indent ) const

--- a/test/ReadInDisplacements.h
+++ b/test/ReadInDisplacements.h
@@ -21,7 +21,7 @@
 
 #include "itkImageFileReader.h"
 
-template< class TDisplacementImageType  >
+template< typename TDisplacementImageType  >
 int ReadInDisplacements( const char * inputFile, typename TDisplacementImageType::Pointer & inputImage )
 {
   using InputImageType = TDisplacementImageType;

--- a/test/WriteOutStrains.h
+++ b/test/WriteOutStrains.h
@@ -25,7 +25,7 @@
 #include "itkNthElementImageAdaptor.h"
 #include "itkVTKImageIO.h"
 
-template< class TPixel, unsigned int Dimension, class TTensorImage >
+template< typename TPixel, unsigned int Dimension, typename TTensorImage >
 int WriteOutStrains( const char * outputPrefix, TTensorImage * strainImage )
 {
   using PixelType = TPixel;


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.