### PR TITLE
COMP: Add testing ITKIOVTK and update Jacobian Type

### DIFF
--- a/include/itkTransformToStrainFilter.hxx
+++ b/include/itkTransformToStrainFilter.hxx
@@ -67,13 +67,8 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
   using ImageIteratorType = ImageRegionIteratorWithIndex< OutputImageType >;
   ImageIteratorType outputIt( output, region );
 
-  typename TransformType::JacobianType identity;
-  identity.SetSize( ImageDimension, ImageDimension );
-  identity.Fill( 0.0 );
-  for( unsigned int i = 0; i < ImageDimension; ++i )
-    {
-    identity.SetElement( i, i, 1.0);
-    }
+  typename TransformType::JacobianPositionType identity;
+  identity.set_identity();
 
   // e_ij += 1/2( du_i/dx_j + du_j/dx_i )
   for( outputIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt )
@@ -81,7 +76,7 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
     const typename OutputImageType::IndexType index = outputIt.GetIndex();
     typename OutputImageType::PointType point;
     output->TransformIndexToPhysicalPoint( index, point );
-    typename TransformType::JacobianType jacobian;
+    typename TransformType::JacobianPositionType jacobian;
     input->ComputeJacobianWithRespectToPosition( point, jacobian );
     typename OutputImageType::PixelType outputPixel = outputIt.Get();
     for( unsigned int i = 0; i < ImageDimension; ++i )
@@ -109,7 +104,7 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
       const typename OutputImageType::IndexType index = outputIt.GetIndex();
       typename OutputImageType::PointType point;
       output->TransformIndexToPhysicalPoint( index, point );
-      typename TransformType::JacobianType jacobian;
+      typename TransformType::JacobianPositionType jacobian;
       input->ComputeJacobianWithRespectToPosition( point, jacobian );
       jacobian -= identity;
       typename OutputImageType::PixelType outputPixel = outputIt.Get();
@@ -133,7 +128,7 @@ TransformToStrainFilter< TTransform, TOperatorValue, TOutputValue >
       const typename OutputImageType::IndexType index = outputIt.GetIndex();
       typename OutputImageType::PointType point;
       output->TransformIndexToPhysicalPoint( index, point );
-      typename TransformType::JacobianType jacobian;
+      typename TransformType::JacobianPositionType jacobian;
       input->ComputeJacobianWithRespectToPosition( point, jacobian );
       jacobian -= identity;
       typename OutputImageType::PixelType outputPixel = outputIt.Get();

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -8,6 +8,7 @@ itk_module(Strain
     ITKImageSources
   TEST_DEPENDS
     ITKTestKernel
+    ITKIOVTK
     ITKDisplacementField
     ITKIOVTK
   EXCLUDE_FROM_DEFAULT


### PR DESCRIPTION
JacobianType -> JacobianPositionType

With fixed Jacobian dimensions, use
set identity instead of manually
creating an identity matrix.