### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -48,7 +48,7 @@ template <typename TInputImage, typename TOutputImage, unsigned int TComponents 
 class SplitComponentsImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(SplitComponentsImageFilter);
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkStrainImageFilter.h
+++ b/include/itkStrainImageFilter.h
@@ -66,7 +66,7 @@ class StrainImageFilter
       Image<SymmetricSecondRankTensor<TOutputValueType, TInputImage::ImageDimension>, TInputImage::ImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(StrainImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(StrainImageFilter);
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkTransformToStrainFilter.h
+++ b/include/itkTransformToStrainFilter.h
@@ -56,7 +56,7 @@ class TransformToStrainFilter
                                      TTransform::InputSpaceDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TransformToStrainFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(TransformToStrainFilter);
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TTransform::InputSpaceDimension;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.