### PR TITLE
ENH: Add types to StrainImageFilter wrappings

### DIFF
--- a/wrapping/itkStrainImageFilter.wrap
+++ b/wrapping/itkStrainImageFilter.wrap
@@ -1,8 +1,10 @@
+UNIQUE(types "D;${WRAP_ITK_REAL}")
+
 itk_wrap_include("itkImageToImageFilter.h")
 itk_wrap_class("itk::ImageToImageFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     set(vector_dim ${d}) # Wrap only vector dimensions which are the same as image dimensions
-    foreach(p D)
+    foreach(p ${types})
       itk_wrap_template(
         "${ITKM_IV${p}${vector_dim}${d}}${ITKM_ISSRT${p}${d}${d}}"
         "${ITKT_IV${p}${vector_dim}${d}}, ${ITKT_ISSRT${p}${d}${d}}")
@@ -16,7 +18,7 @@ itk_end_wrap_class()
 itk_wrap_class("itk::StrainImageFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     set(vector_dim ${d}) # Wrap only vector dimensions which are the same as image dimensions
-    foreach(p D)
+    foreach(p ${types})
       itk_wrap_template(
         "${ITKM_IV${p}${vector_dim}${d}}${ITKM_${p}}${ITKM_${p}}"
         "${ITKT_IV${p}${vector_dim}${d}}, ${ITKT_${p}}, ${ITKT_${p}}")


### PR DESCRIPTION
Extending `StrainImageFilter` with wrapping for `float` input type. May require additional wrappings in ITK dependencies prior to review.