### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSplitComponentsImageFilter_hxx
 #define itkSplitComponentsImageFilter_hxx
 
-#include "itkSplitComponentsImageFilter.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"

--- a/include/itkStrainImageFilter.hxx
+++ b/include/itkStrainImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkStrainImageFilter_hxx
 #define itkStrainImageFilter_hxx
 
-#include "itkStrainImageFilter.h"
 
 #include "itkGradientImageFilter.h"
 #include "itkImageRegionConstIterator.h"

--- a/include/itkTransformToStrainFilter.hxx
+++ b/include/itkTransformToStrainFilter.hxx
@@ -19,7 +19,6 @@
 #define itkTransformToStrainFilter_hxx
 
 #include "itkImageRegionIteratorWithIndex.h"
-#include "itkTransformToStrainFilter.h"
 
 namespace itk
 {


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

