### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -71,7 +71,7 @@ public:
   using ComponentsMaskType = FixedArray<bool, TComponents>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SplitComponentsImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SplitComponentsImageFilter);
 
   /** Method of creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkStrainImageFilter.h
+++ b/include/itkStrainImageFilter.h
@@ -96,7 +96,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(StrainImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(StrainImageFilter);
 
   /** Set the filter used to calculate the gradients internally. The default is
    * an itk::GradientImageFilter. */

--- a/include/itkTransformToStrainFilter.h
+++ b/include/itkTransformToStrainFilter.h
@@ -77,7 +77,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(TransformToStrainFilter, GenerateImageSource);
+  itkOverrideGetNameOfClassMacro(TransformToStrainFilter);
 
   /** Get/Set the coordinate transformation.
    * Set the coordinate transform to use for resampling.  Note that this must


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
